### PR TITLE
Pre-calculation Checks and Embedding Exports

### DIFF
--- a/tasnif/tasnif.py
+++ b/tasnif/tasnif.py
@@ -56,7 +56,10 @@ class Tasnif:
         The function calculates embeddings, performs PCA, and applies K-means clustering to the
         embeddings.
         """
-
+        if not self.images:
+            logging.warning("No images have been read. Please call the read method before calculating.")
+            return
+        
         self.embeddings = get_embeddings(use_gpu=self.use_gpu, images=self.images)
         self.pca_embeddings = calculate_pca(self.embeddings, self.pca_dim)
         self.centroid, self.labels, self.counts = calculate_kmeans(

--- a/tasnif/tasnif.py
+++ b/tasnif/tasnif.py
@@ -55,12 +55,12 @@ class Tasnif:
     def calculate(self):
         """
         The function calculates embeddings, performs PCA, and applies K-means clustering to the
-        embeddings.
+        embeddings. It will not perform these operations if no images have been read.
         """
+
         if not self.images:
-            logging.warning("No images have been read. Please call the read method before calculating.")
-            return
-        
+            raise ValueError("The images list can not be empty. Please call the read method before calculating.")
+
         self.embeddings = get_embeddings(use_gpu=self.use_gpu, images=self.images)
         self.pca_embeddings = calculate_pca(self.embeddings, self.pca_dim)
         self.centroid, self.labels, self.counts = calculate_kmeans(
@@ -111,9 +111,10 @@ class Tasnif:
         Parameters:
         - output_folder (str): The directory to export the embeddings into.
         """
+        
         if self.embeddings is None:
-            logging.warning("Embeddings have not been calculated. Please call the calculate method first.")
-            return
+            raise ValueError("Embeddings can not be empty. Please call the calculate method first.")
+            
         
         embeddings_path = os.path.join(output_folder, f"{self.project_name}_embeddings.npy")
         np.save(embeddings_path, self.embeddings)

--- a/tasnif/tasnif.py
+++ b/tasnif/tasnif.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import warnings
 from itertools import compress
+import numpy as np
 
 from rich.logging import RichHandler
 from tqdm import tqdm
@@ -101,3 +102,19 @@ class Tasnif:
             create_image_grid(label_images, project_path, label_number)
 
         logging.info(f"Exported images and grids to {project_path}")
+
+
+    def export_embeddings(self, output_folder="./"):
+        """
+        Export the calculated embeddings to a specified output folder.
+
+        Parameters:
+        - output_folder (str): The directory to export the embeddings into.
+        """
+        if self.embeddings is None:
+            logging.warning("Embeddings have not been calculated. Please call the calculate method first.")
+            return
+        
+        embeddings_path = os.path.join(output_folder, f"{self.project_name}_embeddings.npy")
+        np.save(embeddings_path, self.embeddings)
+        logging.info(f"Embeddings have been saved to {embeddings_path}")


### PR DESCRIPTION
I implemented a safeguard in the calculation method to ensure that PCA and k-means clustering calculations are only performed if images have been successfully read into the system. I added the ability to export image embeddings to a specified directory as a ".npy" file through the export_embeddings method. 